### PR TITLE
smart graph support

### DIFF
--- a/nx_arangodb/classes/dict/node.py
+++ b/nx_arangodb/classes/dict/node.py
@@ -324,8 +324,8 @@ class NodeDict(UserDict[str, NodeAttrDict]):
         if node_id not in self.data and self.FETCHED_ALL_IDS:
             raise KeyError(key)
 
-        if vertex_db := vertex_get(self.graph, node_id):
-            node_attr_dict = self._create_node_attr_dict(vertex_db["_id"], vertex_db)
+        if node := vertex_get(self.graph, node_id):
+            node_attr_dict = self._create_node_attr_dict(node["_id"], node)
             self.data[node_id] = node_attr_dict
 
             return node_attr_dict

--- a/nx_arangodb/classes/dict/node.py
+++ b/nx_arangodb/classes/dict/node.py
@@ -334,18 +334,16 @@ class NodeDict(UserDict[str, NodeAttrDict]):
 
     @key_is_string
     def __setitem__(self, key: str, value: NodeAttrDict) -> None:
-        """G._node['node/1'] = {'foo': 'bar'}
-
-        Not to be confused with:
-        - G.add_node('node/1', foo='bar')
-        """
+        """G._node['node/1'] = {'foo': 'bar'}"""
         assert isinstance(value, NodeAttrDict)
 
         node_type, node_id = get_node_type_and_id(key, self.default_node_type)
 
         result = doc_insert(self.db, node_type, node_id, value.data)
 
-        node_attr_dict = self._create_node_attr_dict(result["_id"], value.data)
+        node_attr_dict = self._create_node_attr_dict(
+            result["_id"], {**value.data, **result}
+        )
 
         self.data[node_id] = node_attr_dict
 

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -300,7 +300,6 @@ class DiGraph(Graph, nx.DiGraph):
                 self._node[n] = node_attr_dict
 
             else:
-
                 self._node[n].update(newdict)
 
                 # Reason:

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -126,10 +126,11 @@ class DiGraph(Graph, nx.DiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to drop & re-create the graph collections before loading
+        **incoming_graph_data** into the graph. NOTE: This parameter only
+        applies if the graph already exists in the database. NOTE: Dropping
+        the graph collections will erase all properties of the collections, including
+        created indexes.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -300,7 +300,7 @@ class DiGraph(Graph, nx.DiGraph):
                 # Reason:
                 # We can optimize the process of adding a node by creating avoiding
                 # the creation of a new dictionary and updating it with the attributes.
-                # Instead, we can create a new node_attr_dict object and set the attributes
+                # Instead, we create a new node_attr_dict object and set the attributes
                 # directly. This only makes 1 network call to the database instead of 2.
 
                 ###########################

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -194,6 +194,7 @@ class DiGraph(Graph, nx.DiGraph):
             and not self._loaded_incoming_graph_data
         ):
             nx.convert.to_networkx_graph(incoming_graph_data, create_using=self)
+            self._loaded_incoming_graph_data = True
 
     #######################
     # nx.DiGraph Overides #
@@ -241,12 +242,25 @@ class DiGraph(Graph, nx.DiGraph):
             # attr_dict.update(attr)
 
             # New:
+
+            node_attr_dict = self.node_attr_dict_factory()
+
+            if self.is_smart:
+                if self.smart_field not in attr:
+                    m = f"Node {node_for_adding} missing smart field '{self.smart_field}'"  # noqa: E501
+                    raise KeyError(m)
+
+                node_attr_dict.data[self.smart_field] = attr[self.smart_field]
+
             self._node[node_for_adding] = self.node_attr_dict_factory()
             self._node[node_for_adding].update(attr)
 
             # Reason:
             # Invoking `update` on the `attr_dict` without `attr_dict.node_id` being set
             # i.e trying to update a node's attributes before we know _which_ node it is
+            # Furthermore, support for ArangoDB Smart Graphs requires the smart field
+            # to be set before adding the node to the graph. This is because the smart
+            # field is used to generate the node's key.
 
             ###########################
 

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -154,6 +154,7 @@ class DiGraph(Graph, nx.DiGraph):
         write_async: bool = True,
         symmetrize_edges: bool = False,
         use_arango_views: bool = False,
+        overwrite_graph: bool = False,
         *args: Any,
         **kwargs: Any,
     ):
@@ -171,6 +172,7 @@ class DiGraph(Graph, nx.DiGraph):
             write_async,
             symmetrize_edges,
             use_arango_views,
+            overwrite_graph,
             *args,
             **kwargs,
         )

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -232,15 +232,6 @@ class DiGraph(Graph, nx.DiGraph):
         if node_for_adding is None:
             raise ValueError("None cannot be a node")
 
-        # New:
-        # if self.is_smart:
-        # node_for_adding = self._get_smart_id(node_for_adding, attr)
-
-        # Reason:
-        # Support for ArangoDB Smart Graphs requires the smart field
-        # to be set before adding the node to the graph. This is because
-        # the smart field is used to generate the node's key.
-
         if node_for_adding not in self._succ:
 
             self._succ[node_for_adding] = self.adjlist_inner_dict_factory()

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -125,6 +125,12 @@ class DiGraph(Graph, nx.DiGraph):
         whenever possible. NOTE: This feature is experimental and may not work
         as expected.
 
+    overwrite_graph : bool (optional, default: False)
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
+
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.
 

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -126,10 +126,10 @@ class DiGraph(Graph, nx.DiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to overwrite the graph in the database if it already exists. If
+        set to True, the graph collections will be dropped and recreated. Note that
+        this operation is irreversible and will result in the loss of all data in
+        the graph. NOTE: If set to True, Collection Indexes will also be lost.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -272,7 +272,7 @@ class DiGraph(Graph, nx.DiGraph):
 
     # TODO: Address in separate PR
     # def add_nodes_from_override(self, nodes_for_adding, **attr):
-        # raise NotImplementedError("Not yet implemented")
+    #     raise NotImplementedError("Not yet implemented")
 
     def remove_node_override(self, n):
         if isinstance(n, (str, int)):

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -60,8 +60,8 @@ class DiGraph(Graph, nx.DiGraph):
     name : str (optional, default: None)
         Name of the graph in the database. If the graph already exists,
         the user can pass the name of the graph to connect to it. If
-        the graph does not exist, the user can create a new graph by
-        passing the name. NOTE: Must be used in conjunction with
+        the graph does not exist, a General Graph will be created by
+        passing the **name**. NOTE: Must be used in conjunction with
         **incoming_graph_data** if the user wants to persist the graph
         in ArangoDB.
 

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -126,11 +126,10 @@ class DiGraph(Graph, nx.DiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to drop & re-create the graph collections before loading
-        **incoming_graph_data** into the graph. NOTE: This parameter only
-        applies if the graph already exists in the database. NOTE: Dropping
-        the graph collections will erase all properties of the collections, including
-        created indexes.
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/digraph.py
+++ b/nx_arangodb/classes/digraph.py
@@ -180,7 +180,7 @@ class DiGraph(Graph, nx.DiGraph):
         if self.graph_exists_in_db:
             self.clear_edges = self.clear_edges_override
             self.add_node = self.add_node_override
-            # self.add_nodes_from = self.add_nodes_from_override
+            self.add_nodes_from = self.add_nodes_from_override
             self.remove_node = self.remove_node_override
             self.reverse = self.reverse_override
 
@@ -263,9 +263,49 @@ class DiGraph(Graph, nx.DiGraph):
 
         nx._clear_cache(self)
 
-    # TODO: Address in separate PR
-    # def add_nodes_from_override(self, nodes_for_adding, **attr):
-    #     raise NotImplementedError("Not yet implemented")
+    def add_nodes_from_override(self, nodes_for_adding, **attr):
+        for n in nodes_for_adding:
+            try:
+                newnode = n not in self._node
+                newdict = attr
+            except TypeError:
+                n, ndict = n
+                newnode = n not in self._node
+                newdict = attr.copy()
+                newdict.update(ndict)
+            if newnode:
+                if n is None:
+                    raise ValueError("None cannot be a node")
+                self._succ[n] = self.adjlist_inner_dict_factory()
+                self._pred[n] = self.adjlist_inner_dict_factory()
+
+                ######################
+                # NOTE: monkey patch #
+                ######################
+
+                # Old:
+                #   self._node[n] = self.node_attr_dict_factory()
+                #
+                # self._node[n].update(newdict)
+
+                # New:
+                node_attr_dict = self.node_attr_dict_factory()
+                node_attr_dict.data = newdict
+                self._node[n] = node_attr_dict
+
+            else:
+
+                self._node[n].update(newdict)
+
+                # Reason:
+                # We can optimize the process of adding a node by creating avoiding
+                # the creation of a new dictionary and updating it with the attributes.
+                # Instead, we can create a new node_attr_dict object and set the attributes
+                # directly. This only makes 1 network call to the database instead of 2.
+
+                ###########################
+
+        nx._clear_cache(self)
 
     def remove_node_override(self, n):
         if isinstance(n, (str, int)):

--- a/nx_arangodb/classes/function.py
+++ b/nx_arangodb/classes/function.py
@@ -199,6 +199,17 @@ def json_serializable(cls):
     return cls
 
 
+def cast_to_string(value: Any) -> str:
+    """Casts a value to a string."""
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    raise TypeError(f"{value} cannot be casted to string.")
+
+
 def key_is_string(func: Callable[..., Any]) -> Any:
     """Decorator to check if the key is a string.
     Will attempt to cast the key to a string if it is not.
@@ -208,12 +219,7 @@ def key_is_string(func: Callable[..., Any]) -> Any:
         if key is None:
             raise ValueError("Key cannot be None.")
 
-        if not isinstance(key, str):
-            if not isinstance(key, (int, float)):
-                raise TypeError(f"{key} cannot be casted to string.")
-
-            key = str(key)
-
+        key = cast_to_string(key)
         return func(self, key, *args, **kwargs)
 
     return wrapper
@@ -270,12 +276,7 @@ def keys_are_strings(func: Callable[..., Any]) -> Any:
             raise TypeError(f"Decorator found unsupported type: {type(data)}.")
 
         for key, value in items:
-            if not isinstance(key, str):
-                if not isinstance(key, (int, float)):
-                    raise TypeError(f"{key} cannot be casted to string.")
-
-                key = str(key)
-
+            key = cast_to_string(key)
             data_dict[key] = value
 
         return func(self, data_dict, *args, **kwargs)
@@ -655,7 +656,7 @@ def doc_insert(
     data: dict[str, Any] = {},
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Inserts a document into a collection."""
+    """Inserts a document into a collection. Returns document metadata."""
     result: dict[str, Any] = db.insert_document(
         collection, {**data, "_id": id}, overwrite=True, **kwargs
     )

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -29,7 +29,7 @@ from .dict import (
     node_attr_dict_factory,
     node_dict_factory,
 )
-from .function import cast_to_string, get_node_id
+from .function import get_node_id
 from .reportviews import ArangoEdgeView, ArangoNodeView
 
 networkx_api = nxadb.utils.decorators.networkx_class(nx.Graph)  # type: ignore
@@ -614,24 +614,6 @@ class Graph(nx.Graph):
 
         return str(response["result"])
 
-    def _get_smart_id(self, node_for_adding: str, attr: dict[Any, Any]) -> str:
-        raise NotImplementedError(
-            "This is broken if node_for_adding is structured like an ArangoDB ID"
-        )  # noqa: E501
-        # Should we really be doing this? Database would catch this error anyways...
-
-        if self.smart_field not in attr:
-            m = f"Node {node_for_adding} missing smart field '{self.smart_field}'"  # noqa: E501
-            raise KeyError(m)
-
-        # TODO: Revisit this behaviour.
-        # Too magical? Raise error instead? Let ArangoDB handle it?
-        node_for_adding = cast_to_string(node_for_adding)
-        if ":" not in node_for_adding:
-            node_for_adding = f"{attr[self.smart_field]}:{node_for_adding}"
-
-        return node_for_adding
-
     #####################
     # nx.Graph Overides #
     #####################
@@ -698,15 +680,6 @@ class Graph(nx.Graph):
     def add_node_override(self, node_for_adding, **attr):
         if node_for_adding is None:
             raise ValueError("None cannot be a node")
-
-        # New:
-        # if self.is_smart:
-        # node_for_adding = self._get_smart_id(node_for_adding, attr)
-
-        # Reason:
-        # Support for ArangoDB Smart Graphs requires the smart field
-        # to be set before adding the node to the graph. This is because
-        # the smart field is used to generate the node's key.
 
         if node_for_adding not in self._node:
             self._adj[node_for_adding] = self.adjlist_inner_dict_factory()

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -94,8 +94,8 @@ class Graph(nx.Graph):
     name : str (optional, default: None)
         Name of the graph in the database. If the graph already exists,
         the user can pass the name of the graph to connect to it. If
-        the graph does not exist, the user can create a new graph by
-        passing the name. NOTE: Must be used in conjunction with
+        the graph does not exist, a General Graph will be created by
+        passing the **name**. NOTE: Must be used in conjunction with
         **incoming_graph_data** if the user wants to persist the graph
         in ArangoDB.
 

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -746,7 +746,7 @@ class Graph(nx.Graph):
                 # Reason:
                 # We can optimize the process of adding a node by creating avoiding
                 # the creation of a new dictionary and updating it with the attributes.
-                # Instead, we can create a new node_attr_dict object and set the attributes
+                # Instead, we create a new node_attr_dict object and set the attributes
                 # directly. This only makes 1 network call to the database instead of 2.
 
                 ###########################

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -160,10 +160,11 @@ class Graph(nx.Graph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to drop & re-create the graph collections before loading
+        **incoming_graph_data** into the graph. NOTE: This parameter only
+        applies if the graph already exists in the database. NOTE: Dropping
+        the graph collections will erase all properties of the collections, including
+        created indexes.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.
@@ -231,13 +232,16 @@ class Graph(nx.Graph):
             self.__set_arangodb_backend_config(read_parallelism, read_batch_size)
 
             if overwrite_graph:
-                logger.info("Truncating graph collections...")
+                logger.info("Overwriting graph collections...")
 
                 for col in self.adb_graph.vertex_collections():
-                    self.db.collection(col).truncate()
+                    self.db.delete_collection(col)
+                    self.db.create_collection(col)
 
-                for col in self.adb_graph.edge_definitions():
-                    self.db.collection(col["edge_collection"]).truncate()
+                for ed in self.adb_graph.edge_definitions():
+                    col = ed["edge_collection"]
+                    self.db.delete_collection(col)
+                    self.db.create_collection(col, edge=True)
 
             if isinstance(incoming_graph_data, nx.Graph):
                 self._load_nx_graph(incoming_graph_data, write_batch_size, write_async)

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -160,10 +160,10 @@ class Graph(nx.Graph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to overwrite the graph in the database if it already exists. If
+        set to True, the graph collections will be dropped and recreated. Note that
+        this operation is irreversible and will result in the loss of all data in
+        the graph. NOTE: If set to True, Collection Indexes will also be lost.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -746,7 +746,6 @@ class Graph(nx.Graph):
                 self._node[n] = node_attr_dict
 
             else:
-
                 self._node[n].update(newdict)
 
                 # Reason:

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -159,6 +159,12 @@ class Graph(nx.Graph):
         whenever possible. NOTE: This feature is experimental and may not work
         as expected.
 
+    overwrite_graph : bool (optional, default: False)
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
+
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.
 

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -231,13 +231,21 @@ class Graph(nx.Graph):
             self.__set_arangodb_backend_config(read_parallelism, read_batch_size)
 
             if overwrite_graph:
-                logger.info("Truncating graph collections...")
+                logger.info("Overwriting graph...")
 
-                for col in self.adb_graph.vertex_collections():
-                    self.db.collection(col).truncate()
-
-                for col in self.adb_graph.edge_definitions():
-                    self.db.collection(col["edge_collection"]).truncate()
+                properties = self.adb_graph.properties()
+                self.db.delete_graph(name, drop_collections=True)
+                self.db.create_graph(
+                    name=name,
+                    edge_definitions=properties["edge_definitions"],
+                    orphan_collections=properties["orphan_collections"],
+                    smart=properties.get("smart"),
+                    disjoint=properties.get("disjoint"),
+                    smart_field=properties.get("smart_field"),
+                    shard_count=properties.get("shard_count"),
+                    replication_factor=properties.get("replication_factor"),
+                    write_concern=properties.get("write_concern"),
+                )
 
             if isinstance(incoming_graph_data, nx.Graph):
                 self._load_nx_graph(incoming_graph_data, write_batch_size, write_async)

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -725,7 +725,7 @@ class Graph(nx.Graph):
 
     # TODO: Address in separate PR
     # def add_nodes_from_override(self, nodes_for_adding, **attr):
-        # raise NotImplementedError("Not yet implemented")
+    #     raise NotImplementedError("Not yet implemented")
 
     def number_of_edges_override(self, u=None, v=None):
         if u is not None:

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -136,10 +136,10 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to overwrite the graph in the database if it already exists. If
+        set to True, the graph collections will be dropped and recreated. Note that
+        this operation is irreversible and will result in the loss of all data in
+        the graph. NOTE: If set to True, Collection Indexes will also be lost.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -70,8 +70,8 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
     name : str (optional, default: None)
         Name of the graph in the database. If the graph already exists,
         the user can pass the name of the graph to connect to it. If
-        the graph does not exist, the user can create a new graph by
-        passing the name. NOTE: Must be used in conjunction with
+        the graph does not exist, a General Graph will be created by
+        passing the **name**. NOTE: Must be used in conjunction with
         **incoming_graph_data** if the user wants to persist the graph
         in ArangoDB.
 

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -165,6 +165,7 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
         write_async: bool = True,
         symmetrize_edges: bool = False,
         use_arango_views: bool = False,
+        overwrite_graph: bool = False,
         *args: Any,
         **kwargs: Any,
     ):
@@ -183,6 +184,7 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
             write_async,
             symmetrize_edges,
             use_arango_views,
+            overwrite_graph,
             *args,
             **kwargs,
         )

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -136,11 +136,10 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to drop & re-create the graph collections before loading
-        **incoming_graph_data** into the graph. NOTE: This parameter only
-        applies if the graph already exists in the database. NOTE: Dropping
-        the graph collections will erase all properties of the collections, including
-        created indexes.
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -136,10 +136,11 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to drop & re-create the graph collections before loading
+        **incoming_graph_data** into the graph. NOTE: This parameter only
+        applies if the graph already exists in the database. NOTE: Dropping
+        the graph collections will erase all properties of the collections, including
+        created indexes.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/multidigraph.py
+++ b/nx_arangodb/classes/multidigraph.py
@@ -135,6 +135,12 @@ class MultiDiGraph(MultiGraph, DiGraph, nx.MultiDiGraph):
         whenever possible. NOTE: This feature is experimental and may not work
         as expected.
 
+    overwrite_graph : bool (optional, default: False)
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
+
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.
 

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -136,6 +136,12 @@ class MultiGraph(Graph, nx.MultiGraph):
         whenever possible. NOTE: This feature is experimental and may not work
         as expected.
 
+    overwrite_graph : bool (optional, default: False)
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
+
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.
 

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -215,6 +215,8 @@ class MultiGraph(Graph, nx.MultiGraph):
             else:
                 nx.convert.to_networkx_graph(incoming_graph_data, create_using=self)
 
+            self._loaded_incoming_graph_data = True
+
     #######################
     # Init helper methods #
     #######################

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -137,10 +137,10 @@ class MultiGraph(Graph, nx.MultiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to overwrite the graph in the database if it already exists. If
+        set to True, the graph collections will be dropped and recreated. Note that
+        this operation is irreversible and will result in the loss of all data in
+        the graph. NOTE: If set to True, Collection Indexes will also be lost.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -137,11 +137,10 @@ class MultiGraph(Graph, nx.MultiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to drop & re-create the graph collections before loading
-        **incoming_graph_data** into the graph. NOTE: This parameter only
-        applies if the graph already exists in the database. NOTE: Dropping
-        the graph collections will erase all properties of the collections, including
-        created indexes.
+        Whether to truncate the graph collections when the graph is loaded from
+        the database. If set to True, the graph collections will be truncated
+        before loading the graph data. NOTE: This parameter only applies if the
+        graph already exists in the database.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -71,8 +71,8 @@ class MultiGraph(Graph, nx.MultiGraph):
     name : str (optional, default: None)
         Name of the graph in the database. If the graph already exists,
         the user can pass the name of the graph to connect to it. If
-        the graph does not exist, the user can create a new graph by
-        passing the name. NOTE: Must be used in conjunction with
+        the graph does not exist, a General Graph will be created by
+        passing the **name**. NOTE: Must be used in conjunction with
         **incoming_graph_data** if the user wants to persist the graph
         in ArangoDB.
 

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -166,6 +166,7 @@ class MultiGraph(Graph, nx.MultiGraph):
         write_async: bool = True,
         symmetrize_edges: bool = False,
         use_arango_views: bool = False,
+        overwrite_graph: bool = False,
         *args: Any,
         **kwargs: Any,
     ):
@@ -183,6 +184,7 @@ class MultiGraph(Graph, nx.MultiGraph):
             write_async,
             symmetrize_edges,
             use_arango_views,
+            overwrite_graph,
             *args,
             **kwargs,
         )

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -137,10 +137,11 @@ class MultiGraph(Graph, nx.MultiGraph):
         as expected.
 
     overwrite_graph : bool (optional, default: False)
-        Whether to truncate the graph collections when the graph is loaded from
-        the database. If set to True, the graph collections will be truncated
-        before loading the graph data. NOTE: This parameter only applies if the
-        graph already exists in the database.
+        Whether to drop & re-create the graph collections before loading
+        **incoming_graph_data** into the graph. NOTE: This parameter only
+        applies if the graph already exists in the database. NOTE: Dropping
+        the graph collections will erase all properties of the collections, including
+        created indexes.
 
     args: positional arguments for nx.Graph
         Additional arguments passed to nx.Graph.

--- a/nx_arangodb/exceptions.py
+++ b/nx_arangodb/exceptions.py
@@ -14,6 +14,10 @@ class GraphNameNotSet(NetworkXArangoDBException):
     pass
 
 
+class GraphNotEmpty(NetworkXArangoDBException):
+    pass
+
+
 class InvalidTraversalDirection(NetworkXArangoDBException):
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ classifiers = [
 ]
 dependencies = [
     "networkx>=3.0,<=3.3",
-    "phenolrs",
-    "python-arango",
-    "adbnx-adapter"
+    "phenolrs~=0.5",
+    "python-arango~=8",
+    "adbnx-adapter~=5"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "networkx>=3.0,<=3.3",
     "phenolrs~=0.5",
     "python-arango~=8.1",
-    "adbnx-adapter~=5.0"
+    "adbnx-adapter~=5.0.5"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 dependencies = [
     "networkx>=3.0,<=3.3",
     "phenolrs~=0.5",
-    "python-arango~=8",
-    "adbnx-adapter~=5"
+    "python-arango~=8.1",
+    "adbnx-adapter~=5.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test.py
+++ b/tests/test.py
@@ -167,7 +167,7 @@ def test_load_graph_from_nxadb_as_smart_graph():
     assert G["Mr.Hi:0"]["Officer:35"]["weight"] == 5
 
     G.add_nodes_from(
-        [("Officer:36", {"club": "Officer"}), ("Mr.Hi:37", {"club": "Mr.Hibl"})]
+        [("Officer:36", {"club": "Officer"}), ("Mr.Hi:37", {"club": "Mr.Hi"})]
     )
     assert G.has_node("Officer:36")
     assert G.has_node("Mr.Hi:37")

--- a/tests/test.py
+++ b/tests/test.py
@@ -174,6 +174,18 @@ def test_load_graph_from_nxadb_as_smart_graph():
     assert G.has_node("Officer:36")
     assert G.has_node("Mr.Hi:37")
 
+    assert db.collection("smart_person").properties()["smart"]
+
+    G = nxadb.Graph(
+        name=graph_name,
+        incoming_graph_data=G_NX_copy,
+        write_async=False,
+        overwrite_graph=True,
+    )
+
+    assert db.collection("smart_person").properties()["smart"]
+    assert G.nodes["Mr.Hi:0"]["club"] == "Mr.Hi"
+
     db.delete_graph(graph_name, drop_collections=True)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Union
 
 import networkx as nx
 import pytest
-from arango import DocumentDeleteError
+from arango.exceptions import DocumentInsertError
 from phenolrs.networkx.typings import (
     DiGraphAdjDict,
     GraphAdjDict,
@@ -17,7 +17,7 @@ from nx_arangodb.classes.dict.node import NodeAttrDict, NodeDict
 
 from .conftest import create_grid_graph, create_line_graph, db, run_gpu_tests
 
-G_NX = nx.karate_club_graph()
+G_NX: nx.Graph = nx.karate_club_graph()
 G_NX_digraph = nx.DiGraph(G_NX)
 G_NX_multigraph = nx.MultiGraph(G_NX)
 G_NX_multidigraph = nx.MultiDiGraph(G_NX)
@@ -104,6 +104,73 @@ def test_load_graph_from_nxadb():
     assert db.has_collection("person_to_person")
     assert db.collection("person").count() == len(G_NX.nodes)
     assert db.collection("person_to_person").count() == len(G_NX.edges)
+
+    db.delete_graph(graph_name, drop_collections=True)
+
+
+def test_load_graph_from_nxadb_as_smart_graph():
+    graph_name = "SmartKarateGraph"
+
+    db.delete_graph(graph_name, drop_collections=True, ignore_missing=True)
+    db.create_graph(
+        graph_name,
+        smart=True,
+        smart_field="club",
+        edge_definitions=[
+            {
+                "edge_collection": "smart_person_to_smart_person",
+                "from_vertex_collections": ["smart_person"],
+                "to_vertex_collections": ["smart_person"],
+            }
+        ],
+    )
+
+    G_NX_copy = G_NX.copy()
+    for _, node in G_NX_copy.nodes(data=True):
+        node["club"] = node["club"].replace(" ", "")
+
+    G = nxadb.Graph(
+        name=graph_name,
+        incoming_graph_data=G_NX_copy,
+        write_async=False,
+    )
+
+    assert db.has_graph(graph_name)
+    assert db.has_collection("smart_person")
+    assert db.has_collection("smart_person_to_smart_person")
+    assert db.collection("smart_person").count() == len(G_NX_copy.nodes)
+    assert db.collection("smart_person_to_smart_person").count() == len(G_NX_copy.edges)
+
+    assert db.has_document("smart_person/Mr.Hi:0")
+
+    with pytest.raises(DocumentInsertError):
+        G.add_node(35, club="Officer")
+
+    with pytest.raises(DocumentInsertError):
+        G.add_node("35", club="Officer")
+
+    with pytest.raises(DocumentInsertError):
+        G.add_node("smart_person/35", club="Officer")
+
+    with pytest.raises(DocumentInsertError):
+        G.add_node("smart_person/Officer:35", club="officer")
+
+    with pytest.raises(DocumentInsertError):
+        G.add_node("smart_person/Officer", club="Officer")
+
+    assert G.nodes["Mr.Hi:0"]["club"] == "Mr.Hi"
+    G.add_node("Officer:35", club="Officer")
+    assert G.nodes["smart_person/Officer:35"]["club"] == "Officer"
+
+    assert G["Mr.Hi:0"]["Mr.Hi:1"]["weight"] == 4
+    G.add_edge("Mr.Hi:0", "Officer:35", weight=5)
+    assert G["Mr.Hi:0"]["Officer:35"]["weight"] == 5
+
+    G.add_nodes_from(
+        [("Officer:36", {"club": "Officer"}), ("Mr.Hi:37", {"club": "Mr.Hibl"})]
+    )
+    assert G.has_node("Officer:36")
+    assert G.has_node("Mr.Hi:37")
 
     db.delete_graph(graph_name, drop_collections=True)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -125,6 +125,8 @@ def test_load_graph_from_nxadb_as_smart_graph():
         ],
     )
 
+    # Small preprocessing to remove whitespaces from club names,
+    # as smart graphs do not allow whitespaces in smart fields
     G_NX_copy = G_NX.copy()
     for _, node in G_NX_copy.nodes(data=True):
         node["club"] = node["club"].replace(" ", "")


### PR DESCRIPTION
- Introduces support for Smart Graphs in ArangoDB
- Restructures the `nxadb.Graph` constructor
- Adds `overwrite_graph` as a parameter to support the ability to pass `incoming_graph_data` to a graph that already exists in ArangoDB
- Improvements to `add_node_override`
- Introduces `add_nodes_from_override`
- Locks primary dependencies
- Minor code cleanup