### PR TITLE
new: fully support parameterized `db` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,16 @@ import nx_arangodb as nxadb
 
 G = nxadb.Graph(name="MyGraph")
 
+# Option 1: Use Global Config
 nx.config.backends.arangodb.use_gpu = False
-
 nx.pagerank(G)
 nx.betweenness_centrality(G)
 # ...
-
 nx.config.backends.arangodb.use_gpu = True
+
+# Option 2: Use Local Config
+nx.pagerank(G, use_gpu=False)
+nx.betweenness_centrality(G, use_gpu=False)
 ```
 
 <p align="center">

--- a/_nx_arangodb/__init__.py
+++ b/_nx_arangodb/__init__.py
@@ -74,15 +74,7 @@ def get_info():
     for key in info_keys:
         del d[key]
 
-    d["default_config"] = {
-        "host": None,
-        "username": None,
-        "password": None,
-        "db_name": None,
-        "read_parallelism": None,
-        "read_batch_size": None,
-        "use_gpu": True,
-    }
+    d["default_config"] = {"use_gpu": True}
 
     return d
 

--- a/doc/algorithms/index.rst
+++ b/doc/algorithms/index.rst
@@ -43,13 +43,16 @@ You can also force-run algorithms on CPU even if ``nx-cugraph`` is installed:
 
    G = nxadb.Graph(name="MyGraph")
 
+   # Option 1: Use Global Config
    nx.config.backends.arangodb.use_gpu = False
-
    nx.pagerank(G)
    nx.betweenness_centrality(G)
    # ...
-
    nx.config.backends.arangodb.use_gpu = True
+
+   # Option 2: Use Local Config
+   nx.pagerank(G, use_gpu=False)
+   nx.betweenness_centrality(G, use_gpu=False)
 
 
 .. image:: ../_static/dispatch.png

--- a/doc/nx_arangodb.ipynb
+++ b/doc/nx_arangodb.ipynb
@@ -236,9 +236,7 @@
       "outputs": [],
       "source": [
         "# 5. Run an algorithm (CPU)\n",
-        "nx.config.backends.arangodb.use_gpu = False # Optional\n",
-        "\n",
-        "res = nx.pagerank(G)"
+        "res = nx.pagerank(G, use_gpu=False)"
       ]
     },
     {
@@ -357,8 +355,6 @@
       "source": [
         "# 4. Run an algorithm (GPU)\n",
         "# See *Package Installation* to install nx-cugraph ^\n",
-        "nx.config.backends.arangodb.use_gpu = True\n",
-        "\n",
         "res = nx.pagerank(G)"
       ]
     },

--- a/nx_arangodb/classes/dict/adj.py
+++ b/nx_arangodb/classes/dict/adj.py
@@ -1458,6 +1458,12 @@ class AdjListOuterDict(UserDict[str, AdjListInnerDict]):
     symmetrize_edges_if_directed : bool
         Whether to add the reverse edge if the graph is directed.
 
+    read_parallelism : int
+        The number of parallel threads to use for reading data in _fetch_all.
+
+    read_batch_size : int
+        The number of documents to read in each batch in _fetch_all.
+
     Example
     -------
     >>> g = nxadb.Graph(name="MyGraph")

--- a/nx_arangodb/classes/dict/adj.py
+++ b/nx_arangodb/classes/dict/adj.py
@@ -105,6 +105,8 @@ def adjlist_outer_dict_factory(
     db: StandardDatabase,
     graph: Graph,
     default_node_type: str,
+    read_parallelism: int,
+    read_batch_size: int,
     edge_type_key: str,
     edge_type_func: Callable[[str, str], str],
     graph_type: str,
@@ -115,6 +117,8 @@ def adjlist_outer_dict_factory(
         db,
         graph,
         default_node_type,
+        read_parallelism,
+        read_batch_size,
         edge_type_key,
         edge_type_func,
         graph_type,
@@ -1467,6 +1471,8 @@ class AdjListOuterDict(UserDict[str, AdjListInnerDict]):
         db: StandardDatabase,
         graph: Graph,
         default_node_type: str,
+        read_parallelism: int,
+        read_batch_size: int,
         edge_type_key: str,
         edge_type_func: Callable[[str, str], str],
         graph_type: str,
@@ -1489,6 +1495,8 @@ class AdjListOuterDict(UserDict[str, AdjListInnerDict]):
         self.edge_type_key = edge_type_key
         self.edge_type_func = edge_type_func
         self.default_node_type = default_node_type
+        self.read_parallelism = read_parallelism
+        self.read_batch_size = read_batch_size
         self.adjlist_inner_dict_factory = adjlist_inner_dict_factory(
             db,
             graph,
@@ -1853,6 +1861,8 @@ class AdjListOuterDict(UserDict[str, AdjListInnerDict]):
             is_directed=True,
             is_multigraph=self.is_multigraph,
             symmetrize_edges_if_directed=self.symmetrize_edges_if_directed,
+            read_parallelism=self.read_parallelism,
+            read_batch_size=self.read_batch_size,
         )
 
         # Even if the Graph is undirected,

--- a/nx_arangodb/classes/dict/node.py
+++ b/nx_arangodb/classes/dict/node.py
@@ -260,6 +260,12 @@ class NodeDict(UserDict[str, NodeAttrDict]):
     default_node_type : str
         The default node type for the graph.
 
+    read_parallelism : int
+        The number of parallel threads to use for reading data in _fetch_all.
+
+    read_batch_size : int
+        The number of documents to read in each batch in _fetch_all.
+
     Example
     -------
     >>> G = nxadb.Graph("MyGraph")

--- a/nx_arangodb/classes/dict/node.py
+++ b/nx_arangodb/classes/dict/node.py
@@ -40,10 +40,20 @@ from ..function import (
 
 
 def node_dict_factory(
-    db: StandardDatabase, graph: Graph, default_node_type: str
+    db: StandardDatabase,
+    graph: Graph,
+    default_node_type: str,
+    read_parallelism: int,
+    read_batch_size: int,
 ) -> Callable[..., NodeDict]:
     """Factory function for creating a NodeDict."""
-    return lambda: NodeDict(db, graph, default_node_type)
+    return lambda: NodeDict(
+        db,
+        graph,
+        default_node_type,
+        read_parallelism,
+        read_batch_size,
+    )
 
 
 def node_attr_dict_factory(
@@ -262,6 +272,8 @@ class NodeDict(UserDict[str, NodeAttrDict]):
         db: StandardDatabase,
         graph: Graph,
         default_node_type: str,
+        read_parallelism: int,
+        read_batch_size: int,
         *args: Any,
         **kwargs: Any,
     ):
@@ -271,6 +283,9 @@ class NodeDict(UserDict[str, NodeAttrDict]):
         self.db = db
         self.graph = graph
         self.default_node_type = default_node_type
+        self.read_parallelism = read_parallelism
+        self.read_batch_size = read_batch_size
+
         self.node_attr_dict_factory = node_attr_dict_factory(self.db, self.graph)
 
         self.FETCHED_ALL_DATA = False
@@ -472,6 +487,8 @@ class NodeDict(UserDict[str, NodeAttrDict]):
             is_directed=False,  # not used
             is_multigraph=False,  # not used
             symmetrize_edges_if_directed=False,  # not used
+            read_parallelism=self.read_parallelism,
+            read_batch_size=self.read_batch_size,
         )
 
         for node_id, node_data in node_dict.items():

--- a/nx_arangodb/classes/function.py
+++ b/nx_arangodb/classes/function.py
@@ -145,6 +145,7 @@ def get_arangodb_graph(
         metagraph["edgeCollections"] = {}
 
     hosts = adb_graph._conn._hosts
+    hosts = hosts.split(",") if type(hosts) is str else hosts
     db_name = adb_graph._conn._db_name
     username, password = adb_graph._conn._auth
 

--- a/nx_arangodb/classes/function.py
+++ b/nx_arangodb/classes/function.py
@@ -47,6 +47,8 @@ def get_arangodb_graph(
     is_directed: bool,
     is_multigraph: bool,
     symmetrize_edges_if_directed: bool,
+    read_parallelism: int,
+    read_batch_size: int,
 ) -> Tuple[
     NodeDict,
     GraphAdjDict | DiGraphAdjDict | MultiGraphAdjDict | MultiDiGraphAdjDict,
@@ -142,11 +144,9 @@ def get_arangodb_graph(
     if not load_adj_dict and not load_coo:
         metagraph["edgeCollections"] = {}
 
-    config = nx.config.backends.arangodb
-    assert config.db_name
-    assert config.host
-    assert config.username
-    assert config.password
+    hosts = adb_graph._conn._hosts
+    db_name = adb_graph._conn._db_name
+    username, password = adb_graph._conn._auth
 
     (
         node_dict,
@@ -157,11 +157,11 @@ def get_arangodb_graph(
         vertex_ids_to_index,
         edge_values,
     ) = NetworkXLoader.load_into_networkx(
-        config.db_name,
+        database=db_name,
         metagraph=metagraph,
-        hosts=[config.host],
-        username=config.username,
-        password=config.password,
+        hosts=hosts,
+        username=username,
+        password=password,
         load_adj_dict=load_adj_dict,
         load_coo=load_coo,
         load_all_vertex_attributes=load_all_vertex_attributes,
@@ -169,8 +169,8 @@ def get_arangodb_graph(
         is_directed=is_directed,
         is_multigraph=is_multigraph,
         symmetrize_edges_if_directed=symmetrize_edges_if_directed,
-        parallelism=config.read_parallelism,
-        batch_size=config.read_batch_size,
+        parallelism=read_parallelism,
+        batch_size=read_batch_size,
     )
 
     return (

--- a/nx_arangodb/classes/graph.py
+++ b/nx_arangodb/classes/graph.py
@@ -214,10 +214,12 @@ class Graph(nx.Graph):
         self.use_nxcg_cache = True
         self.nxcg_graph = None
 
+        self.edge_type_key = edge_type_key
+        self.read_parallelism = read_parallelism
+        self.read_batch_size = read_batch_size
+
         # Does not apply to undirected graphs
         self.symmetrize_edges = symmetrize_edges
-
-        self.edge_type_key = edge_type_key
 
         # TODO: Consider this
         # if not self.__graph_name:
@@ -227,8 +229,8 @@ class Graph(nx.Graph):
 
         self._loaded_incoming_graph_data = False
         if self.graph_exists_in_db:
-            self._set_factory_methods()
-            self.__set_arangodb_backend_config(read_parallelism, read_batch_size)
+            self._set_factory_methods(read_parallelism, read_batch_size)
+            self.__set_arangodb_backend_config()
 
             if overwrite_graph:
                 logger.info("Overwriting graph...")
@@ -284,7 +286,7 @@ class Graph(nx.Graph):
     # Init helper methods #
     #######################
 
-    def _set_factory_methods(self) -> None:
+    def _set_factory_methods(self, read_parallelism: int, read_batch_size: int) -> None:
         """Set the factory methods for the graph, _node, and _adj dictionaries.
 
         The ArangoDB CRUD operations are handled by the modified dictionaries.
@@ -299,39 +301,29 @@ class Graph(nx.Graph):
         """
 
         base_args = (self.db, self.adb_graph)
+
         node_args = (*base_args, self.default_node_type)
-        adj_args = (
-            *node_args,
-            self.edge_type_key,
-            self.edge_type_func,
-            self.__class__.__name__,
+        node_args_with_read = (*node_args, read_parallelism, read_batch_size)
+
+        adj_args = (self.edge_type_key, self.edge_type_func, self.__class__.__name__)
+        adj_inner_args = (*node_args, *adj_args)
+        adj_outer_args = (
+            *node_args_with_read,
+            *adj_args,
+            self.symmetrize_edges,
         )
 
         self.graph_attr_dict_factory = graph_dict_factory(*base_args)
 
-        self.node_dict_factory = node_dict_factory(*node_args)
+        self.node_dict_factory = node_dict_factory(*node_args_with_read)
         self.node_attr_dict_factory = node_attr_dict_factory(*base_args)
 
         self.edge_attr_dict_factory = edge_attr_dict_factory(*base_args)
-        self.adjlist_inner_dict_factory = adjlist_inner_dict_factory(*adj_args)
-        self.adjlist_outer_dict_factory = adjlist_outer_dict_factory(
-            *adj_args, self.symmetrize_edges
-        )
+        self.adjlist_inner_dict_factory = adjlist_inner_dict_factory(*adj_inner_args)
+        self.adjlist_outer_dict_factory = adjlist_outer_dict_factory(*adj_outer_args)
 
-    def __set_arangodb_backend_config(
-        self, read_parallelism: int, read_batch_size: int
-    ) -> None:
-        if not all([self._host, self._username, self._password, self._db_name]):
-            m = "Must set all environment variables to use the ArangoDB Backend with an existing graph"  # noqa: E501
-            raise OSError(m)
-
+    def __set_arangodb_backend_config(self) -> None:
         config = nx.config.backends.arangodb
-        config.host = self._host
-        config.username = self._username
-        config.password = self._password
-        config.db_name = self._db_name
-        config.read_parallelism = read_parallelism
-        config.read_batch_size = read_batch_size
         config.use_gpu = True  # Only used by default if nx-cugraph is available
 
     def __set_edge_collections_attributes(self, attributes: set[str] | None) -> None:
@@ -345,7 +337,7 @@ class Graph(nx.Graph):
             self._edge_collections_attributes.add("_id")
 
     def __set_db(self, db: Any = None) -> None:
-        self._host = os.getenv("DATABASE_HOST")
+        self._hosts = os.getenv("DATABASE_HOST", "").split(",")
         self._username = os.getenv("DATABASE_USERNAME")
         self._password = os.getenv("DATABASE_PASSWORD")
         self._db_name = os.getenv("DATABASE_NAME")
@@ -355,17 +347,20 @@ class Graph(nx.Graph):
                 m = "arango.database.StandardDatabase"
                 raise TypeError(m)
 
-            db.version()
+            db.version()  # make sure the connection is valid
             self.__db = db
+            self._db_name = db.name
+            self._hosts = db._conn._hosts
+            self._username, self._password = db._conn._auth
             return
 
-        if not all([self._host, self._username, self._password, self._db_name]):
+        if not all([self._hosts, self._username, self._password, self._db_name]):
             m = "Database environment variables not set. Can't connect to the database"
             logger.warning(m)
             self.__db = None
             return
 
-        self.__db = ArangoClient(hosts=self._host, request_timeout=None).db(
+        self.__db = ArangoClient(hosts=self._hosts, request_timeout=None).db(
             self._db_name, self._username, self._password, verify=True
         )
 

--- a/nx_arangodb/classes/multigraph.py
+++ b/nx_arangodb/classes/multigraph.py
@@ -229,8 +229,8 @@ class MultiGraph(Graph, nx.MultiGraph):
     # Init helper methods #
     #######################
 
-    def _set_factory_methods(self) -> None:
-        super()._set_factory_methods()
+    def _set_factory_methods(self, read_parallelism: int, read_batch_size: int) -> None:
+        super()._set_factory_methods(read_parallelism, read_batch_size)
         self.edge_key_dict_factory = edge_key_dict_factory(
             self.db,
             self.adb_graph,

--- a/nx_arangodb/convert.py
+++ b/nx_arangodb/convert.py
@@ -256,6 +256,8 @@ def nxadb_to_nx(G: nxadb.Graph) -> nx.Graph:
         is_directed=G.is_directed(),
         is_multigraph=G.is_multigraph(),
         symmetrize_edges_if_directed=G.symmetrize_edges if G.is_directed() else False,
+        read_parallelism=G.read_parallelism,
+        read_batch_size=G.read_batch_size,
     )
 
     logger.info(f"Graph '{G.adb_graph.name}' load took {time.time() - start_time}s")
@@ -337,6 +339,8 @@ if GPU_AVAILABLE:
             symmetrize_edges_if_directed=(
                 G.symmetrize_edges if G.is_directed() else False
             ),
+            read_parallelism=G.read_parallelism,
+            read_batch_size=G.read_batch_size,
         )
 
         logger.info(f"Graph '{G.adb_graph.name}' load took {time.time() - start_time}s")

--- a/nx_arangodb/interface.py
+++ b/nx_arangodb/interface.py
@@ -63,7 +63,9 @@ def _auto_func(func_name: str, /, *args: Any, **kwargs: Any) -> Any:
     dfunc = _registered_algorithms[func_name]
 
     backend_priority: list[str] = []
-    if nxadb.convert.GPU_AVAILABLE and nx.config.backends.arangodb.use_gpu:
+
+    use_gpu = bool(kwargs.pop("use_gpu", nx.config.backends.arangodb.use_gpu))
+    if nxadb.convert.GPU_AVAILABLE and use_gpu:
         backend_priority.append("cugraph")
 
     for backend in backend_priority:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 import logging
 import os
-import sys
-from io import StringIO
-from typing import Any
+from typing import Any, Dict
 
 import networkx as nx
 import pytest
@@ -15,6 +13,8 @@ from nx_arangodb.logger import logger
 
 logger.setLevel(logging.INFO)
 
+con: Dict[str, Any]
+client: ArangoClient
 db: StandardDatabase
 run_gpu_tests: bool
 
@@ -30,6 +30,7 @@ def pytest_addoption(parser: Any) -> None:
 
 
 def pytest_configure(config: Any) -> None:
+    global con
     con = {
         "url": config.getoption("url"),
         "username": config.getoption("username"),
@@ -43,10 +44,11 @@ def pytest_configure(config: Any) -> None:
     print("Password: " + con["password"])
     print("Database: " + con["dbName"])
 
+    global client
+    client = ArangoClient(hosts=con["url"])
+
     global db
-    db = ArangoClient(hosts=con["url"]).db(
-        con["dbName"], con["username"], con["password"], verify=True
-    )
+    db = client.db(con["dbName"], con["username"], con["password"], verify=True)
 
     print("Version: " + db.version())
     print("----------------------------------------")
@@ -97,6 +99,12 @@ def load_two_relation_graph() -> None:
     g.create_edge_definition(
         e2, from_vertex_collections=[v2], to_vertex_collections=[v1]
     )
+
+
+def get_db(db_name: str) -> StandardDatabase:
+    global con
+    global client
+    return client.db(db_name, con["username"], con["password"], verify=True)
 
 
 def create_line_graph(load_attributes: set[str]) -> nxadb.Graph:

--- a/tests/test.py
+++ b/tests/test.py
@@ -447,7 +447,12 @@ def test_gpu_pagerank(graph_cls: type[nxadb.Graph]) -> None:
     assert gpu_cached_time < gpu_no_cache_time
     assert_pagerank(res_gpu_cached, res_gpu_no_cache, 10)
 
-    # 4. CPU
+    # 4. CPU (with use_gpu=False)
+    start_cpu_force_no_gpu = time.time()
+    res_cpu_force_no_gpu = nx.pagerank(graph, use_gpu=False)
+    cpu_force_no_gpu_time = time.time() - start_cpu_force_no_gpu
+
+    # 5. CPU
     assert graph.nxcg_graph is not None
     graph.clear_nxcg_cache()
     assert graph.nxcg_graph is None
@@ -456,12 +461,14 @@ def test_gpu_pagerank(graph_cls: type[nxadb.Graph]) -> None:
     start_cpu = time.time()
     res_cpu = nx.pagerank(graph)
     cpu_time = time.time() - start_cpu
+    assert_pagerank(res_cpu, res_cpu_force_no_gpu, 10)
 
     assert graph.nxcg_graph is None
-
     m = "GPU execution should be faster than CPU execution"
     assert gpu_time < cpu_time, m
+    assert gpu_time < cpu_force_no_gpu_time, m
     assert gpu_no_cache_time < cpu_time, m
+    assert gpu_no_cache_time < cpu_force_no_gpu_time, m
     assert_pagerank(res_gpu_no_cache, res_cpu, 10)
 
 


### PR DESCRIPTION
There are limitations with using the NetworkX Config objects to store connection credentials, as that prevents the user from having multiple connections to different ArangoDB databases in one Python session.

This PR minimizes the use of the NetworkX Config object in favour of storing connection information on a per-Graph-object basis.

Related to https://github.com/arangodb/nx-arangodb/discussions/68

In other words:

```python
from arango import ArangoClient
import nx_arangodb as nxadb

db_1 = ArangoClient("http://my_first_deployment:8529").db(...)
db_2 = ArangoClient("http://my_second_deployment:8529").db(...)

G1 = nxadb.Graph(name="MyGraph", db=db_1)

G2 = nxadb.Graph(name="MyGraph2", db=db_2)
```

Also introduces support for passing `use_gpu` to NetworkX Algorithms, e.g `nx.pagerank(G1, use_gpu=False)`